### PR TITLE
Feat#25 팔로우 도메인 기능 구현

### DIFF
--- a/src/main/java/com/leets/team2/xclone/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/controller/FollowController.java
@@ -32,4 +32,10 @@ public class FollowController {
         return ApiData.ok(null);
     }
 
+
+    @DeleteMapping
+    public ResponseEntity<ApiData<Void>> unfollow(@RequestBody FollowDTO.Save dto, @RequestParam String myTag){
+        followService.unfollowUser(dto, myTag);
+        return ApiData.ok(null);
+    }
 }

--- a/src/main/java/com/leets/team2/xclone/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/controller/FollowController.java
@@ -20,6 +20,12 @@ public class FollowController {
         return ApiData.ok(followers);
     }
 
+    @GetMapping("/followings")
+    public ResponseEntity<ApiData<List<FollowDTO.Response>>> getFollowingsByTag(@RequestParam String tag){
+        List<FollowDTO.Response> followings = followService.getFollowings(tag);
+        return ApiData.ok(followings);
+    }
+
     @PostMapping
     public ResponseEntity<ApiData<Void>> follow(@RequestBody FollowDTO.Save dto, @RequestParam String myTag){
         followService.followUser(dto, myTag);

--- a/src/main/java/com/leets/team2/xclone/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/controller/FollowController.java
@@ -5,10 +5,7 @@ import com.leets.team2.xclone.domain.follow.dto.FollowDTO;
 import com.leets.team2.xclone.domain.follow.service.FollowService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -22,4 +19,11 @@ public class FollowController {
         List<FollowDTO.Response> followers = followService.getFollowers(tag);
         return ApiData.ok(followers);
     }
+
+    @PostMapping
+    public ResponseEntity<ApiData<Void>> follow(@RequestBody FollowDTO.Save dto, @RequestParam String myTag){
+        followService.followUser(dto, myTag);
+        return ApiData.ok(null);
+    }
+
 }

--- a/src/main/java/com/leets/team2/xclone/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/controller/FollowController.java
@@ -1,4 +1,25 @@
 package com.leets.team2.xclone.domain.follow.controller;
 
+import com.leets.team2.xclone.common.ApiData;
+import com.leets.team2.xclone.domain.follow.dto.FollowDTO;
+import com.leets.team2.xclone.domain.follow.service.FollowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/follows")
 public class FollowController {
+    private final FollowService followService;
+    @GetMapping("/followers")
+    public ResponseEntity<ApiData<List<FollowDTO.Response>>> getFollowersByTag(@RequestParam String tag){
+        List<FollowDTO.Response> followers = followService.getFollowers(tag);
+        return ApiData.ok(followers);
+    }
 }

--- a/src/main/java/com/leets/team2/xclone/domain/follow/dto/FollowDTO.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/dto/FollowDTO.java
@@ -20,7 +20,7 @@ public class FollowDTO {
             String nickname
     ){}
 
-    public static FollowDTO.Response toDTO(Follow follow){
+    public static FollowDTO.Response followingMemberToResponse(Follow follow){
         Member following = follow.getFollowee();
         return new Response(following.getId(), following.getTag(), following.getNickname());
     }

--- a/src/main/java/com/leets/team2/xclone/domain/follow/dto/FollowDTO.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/dto/FollowDTO.java
@@ -25,4 +25,9 @@ public class FollowDTO {
         return new Response(following.getId(), following.getTag(), following.getNickname());
     }
 
+    public static FollowDTO.Response followerMemberToResponse(Follow follow){
+        Member follower = follow.getFollower();
+        return new Response(follower.getId(), follower.getTag(), follower.getNickname());
+    }
+
 }

--- a/src/main/java/com/leets/team2/xclone/domain/follow/dto/FollowDTO.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/dto/FollowDTO.java
@@ -1,5 +1,7 @@
 package com.leets.team2.xclone.domain.follow.dto;
 
+import com.leets.team2.xclone.domain.follow.entity.Follow;
+import com.leets.team2.xclone.domain.member.entities.Member;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
@@ -17,5 +19,10 @@ public class FollowDTO {
             String tag,
             String nickname
     ){}
+
+    public static FollowDTO.Response toDTO(Follow follow){
+        Member following = follow.getFollowee();
+        return new Response(following.getId(), following.getTag(), following.getNickname());
+    }
 
 }

--- a/src/main/java/com/leets/team2/xclone/domain/follow/entity/Follow.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/entity/Follow.java
@@ -4,15 +4,10 @@ import com.leets.team2.xclone.common.entity.AbstractEntity;
 import com.leets.team2.xclone.domain.member.entities.Member;
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.experimental.SuperBuilder;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "follow")
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class Follow extends AbstractEntity {
     @ManyToOne
@@ -22,4 +17,10 @@ public class Follow extends AbstractEntity {
     @ManyToOne
     @JoinColumn(name = "followee_id")
     private Member followee;    // 팔로잉 대상
+
+    @Builder
+    public Follow(Member follower, Member followee){
+        this.follower = follower;
+        this.followee = followee;
+    }
 }

--- a/src/main/java/com/leets/team2/xclone/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/repository/FollowRepository.java
@@ -10,4 +10,7 @@ import java.util.List;
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     List<Follow> findByFollower_Tag(String tag);
     List<Follow> findByFollowee_Tag(String tag);
+
+    List<Follow> findByFollowee_TagAndFollower_Tag(String followeeTag, String followerTag);
+
 }

--- a/src/main/java/com/leets/team2/xclone/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/repository/FollowRepository.java
@@ -4,6 +4,10 @@ import com.leets.team2.xclone.domain.follow.entity.Follow;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface FollowRepository extends JpaRepository<Follow, Long> {
+    List<Follow> findByFollower_Tag(String tag);
+    List<Follow> findByFollowee_Tag(String tag);
 }

--- a/src/main/java/com/leets/team2/xclone/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/repository/FollowRepository.java
@@ -11,6 +11,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     List<Follow> findByFollower_Tag(String tag);
     List<Follow> findByFollowee_Tag(String tag);
 
-    List<Follow> findByFollowee_TagAndFollower_Tag(String followeeTag, String followerTag);
+    Follow findByFollowee_TagAndFollower_Tag(String followeeTag, String followerTag);
 
 }

--- a/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
@@ -11,9 +11,8 @@ import com.leets.team2.xclone.exception.NoSuchFollowException;
 import com.leets.team2.xclone.exception.NoSuchMemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +34,7 @@ public class FollowService {
                 .toList();
     }
 
+    @Transactional
     public void followUser(FollowDTO.Save dto, String myTag) {
         validateFollow(dto.tag(), myTag);
         Member followee = memberRepository.findByTag(dto.tag()).orElseThrow(NoSuchMemberException::new);
@@ -46,6 +46,7 @@ public class FollowService {
         followRepository.save(followInfo);
     }
 
+    @Transactional
     public void unfollowUser(FollowDTO.Save dto, String myTag) {
         if(myTag.equals(dto.tag())){
             throw new InvalidFollowException();

--- a/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
@@ -34,6 +34,20 @@ public class FollowService {
                 .collect(Collectors.toList());
     }
 
+    public List<FollowDTO.Response> getFollowings(String tag) {
+        List<Follow> followings = followRepository.findByFollower_Tag(tag);
+        return followings.stream()
+                .map(follow -> {
+                    Member following = follow.getFollowee();
+                    return FollowDTO.Response.builder()
+                            .id(following.getId())
+                            .tag(following.getTag())
+                            .nickname(following.getNickname())
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
     public void followUser(FollowDTO.Save dto, String myTag) {
         validateFollow(dto.tag(), myTag);
         Member followee = memberRepository.findByTag(dto.tag()).orElseThrow(NoSuchMemberException::new);
@@ -54,4 +68,5 @@ public class FollowService {
             throw new FollowAlreadyExistsException();
         }
     }
+
 }

--- a/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
@@ -38,7 +38,7 @@ public class FollowService {
     public List<FollowDTO.Response> getFollowings(String tag) {
         List<Follow> followings = followRepository.findByFollower_Tag(tag);
         return followings.stream()
-                .map(FollowDTO::toDTO)
+                .map(FollowDTO::followingMemberToResponse)
                 .toList();
     }
 

--- a/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
@@ -38,15 +38,8 @@ public class FollowService {
     public List<FollowDTO.Response> getFollowings(String tag) {
         List<Follow> followings = followRepository.findByFollower_Tag(tag);
         return followings.stream()
-                .map(follow -> {
-                    Member following = follow.getFollowee();
-                    return FollowDTO.Response.builder()
-                            .id(following.getId())
-                            .tag(following.getTag())
-                            .nickname(following.getNickname())
-                            .build();
-                })
-                .collect(Collectors.toList());
+                .map(FollowDTO::toDTO)
+                .toList();
     }
 
     public void followUser(FollowDTO.Save dto, String myTag) {

--- a/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
@@ -61,6 +61,9 @@ public class FollowService {
     }
 
     public void unfollowUser(FollowDTO.Save dto, String myTag) {
+        if(myTag.equals(dto.tag())){
+            throw new InvalidFollowException();
+        }
         List<Follow> followInfos = followRepository.findByFollowee_TagAndFollower_Tag(dto.tag(), myTag);
         if(followInfos.isEmpty()){
             throw new NoSuchFollowException();

--- a/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
@@ -7,6 +7,7 @@ import com.leets.team2.xclone.domain.member.entities.Member;
 import com.leets.team2.xclone.domain.member.repository.MemberRepository;
 import com.leets.team2.xclone.exception.FollowAlreadyExistsException;
 import com.leets.team2.xclone.exception.InvalidFollowException;
+import com.leets.team2.xclone.exception.NoSuchFollowException;
 import com.leets.team2.xclone.exception.NoSuchMemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -57,6 +58,14 @@ public class FollowService {
                         .followee(followee)
                         .build();
         followRepository.save(followInfo);
+    }
+
+    public void unfollowUser(FollowDTO.Save dto, String myTag) {
+        List<Follow> followInfos = followRepository.findByFollowee_TagAndFollower_Tag(dto.tag(), myTag);
+        if(followInfos.isEmpty()){
+            throw new NoSuchFollowException();
+        }
+        followRepository.deleteAll(followInfos);
     }
 
     private void validateFollow(String followee, String follower){

--- a/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
@@ -24,15 +24,8 @@ public class FollowService {
     public List<FollowDTO.Response> getFollowers(String tag){
         List<Follow> followers = followRepository.findByFollowee_Tag(tag);
         return followers.stream()
-                .map(follow -> {
-                    Member follower = follow.getFollower();
-                    return FollowDTO.Response.builder()
-                            .id(follower.getId())
-                            .tag(follower.getTag())
-                            .nickname(follower.getNickname())
-                            .build();
-                })
-                .collect(Collectors.toList());
+                .map(FollowDTO::followerMemberToResponse)
+                .toList();
     }
 
     public List<FollowDTO.Response> getFollowings(String tag) {

--- a/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
@@ -4,6 +4,8 @@ import com.leets.team2.xclone.domain.follow.dto.FollowDTO;
 import com.leets.team2.xclone.domain.follow.entity.Follow;
 import com.leets.team2.xclone.domain.follow.repository.FollowRepository;
 import com.leets.team2.xclone.domain.member.entities.Member;
+import com.leets.team2.xclone.domain.member.repository.MemberRepository;
+import com.leets.team2.xclone.exception.NoSuchMemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +16,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FollowService {
     private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
 
     public List<FollowDTO.Response> getFollowers(String tag){
         List<Follow> followers = followRepository.findByFollowee_Tag(tag);
@@ -27,5 +30,15 @@ public class FollowService {
                             .build();
                 })
                 .collect(Collectors.toList());
+    }
+
+    public void followUser(FollowDTO.Save dto, String myTag) {
+        Member followee = memberRepository.findByTag(dto.tag()).orElseThrow(NoSuchMemberException::new);
+        Member follower = memberRepository.findByTag(myTag).orElseThrow(NoSuchMemberException::new);
+        Follow followInfo = Follow.builder()
+                        .follower(follower)
+                        .followee(followee)
+                        .build();
+        followRepository.save(followInfo);
     }
 }

--- a/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
@@ -1,11 +1,31 @@
 package com.leets.team2.xclone.domain.follow.service;
 
+import com.leets.team2.xclone.domain.follow.dto.FollowDTO;
+import com.leets.team2.xclone.domain.follow.entity.Follow;
 import com.leets.team2.xclone.domain.follow.repository.FollowRepository;
+import com.leets.team2.xclone.domain.member.entities.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class FollowService {
     private final FollowRepository followRepository;
+
+    public List<FollowDTO.Response> getFollowers(String tag){
+        List<Follow> followers = followRepository.findByFollowee_Tag(tag);
+        return followers.stream()
+                .map(follow -> {
+                    Member follower = follow.getFollower();
+                    return FollowDTO.Response.builder()
+                            .id(follower.getId())
+                            .tag(follower.getTag())
+                            .nickname(follower.getNickname())
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/team2/xclone/domain/follow/service/FollowService.java
@@ -5,6 +5,8 @@ import com.leets.team2.xclone.domain.follow.entity.Follow;
 import com.leets.team2.xclone.domain.follow.repository.FollowRepository;
 import com.leets.team2.xclone.domain.member.entities.Member;
 import com.leets.team2.xclone.domain.member.repository.MemberRepository;
+import com.leets.team2.xclone.exception.FollowAlreadyExistsException;
+import com.leets.team2.xclone.exception.InvalidFollowException;
 import com.leets.team2.xclone.exception.NoSuchMemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,6 +35,7 @@ public class FollowService {
     }
 
     public void followUser(FollowDTO.Save dto, String myTag) {
+        validateFollow(dto.tag(), myTag);
         Member followee = memberRepository.findByTag(dto.tag()).orElseThrow(NoSuchMemberException::new);
         Member follower = memberRepository.findByTag(myTag).orElseThrow(NoSuchMemberException::new);
         Follow followInfo = Follow.builder()
@@ -40,5 +43,15 @@ public class FollowService {
                         .followee(followee)
                         .build();
         followRepository.save(followInfo);
+    }
+
+    private void validateFollow(String followee, String follower){
+        if(followee.equals(follower)){
+            throw new InvalidFollowException();
+        }
+        List<Follow> follows = followRepository.findByFollowee_TagAndFollower_Tag(followee, follower);
+        if (!follows.isEmpty()) {
+            throw new FollowAlreadyExistsException();
+        }
     }
 }

--- a/src/main/java/com/leets/team2/xclone/domain/member/entities/Member.java
+++ b/src/main/java/com/leets/team2/xclone/domain/member/entities/Member.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "member")
+@Table(name = "`member`")
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/leets/team2/xclone/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/leets/team2/xclone/domain/member/repository/MemberRepository.java
@@ -11,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   boolean existsByNicknameAndKakaoId(String nickname, Long kakaoId);
   Optional<Member> findByNicknameAndKakaoId(String nickname, Long kakaoId);
   boolean existsByTag(String tag);
+  Optional<Member> findByTag(String tag);
+
 }

--- a/src/main/java/com/leets/team2/xclone/exception/ErrorInfo.java
+++ b/src/main/java/com/leets/team2/xclone/exception/ErrorInfo.java
@@ -16,7 +16,11 @@ public enum ErrorInfo {
   ALREADY_EXIST_MEMBER(HttpStatus.CONFLICT, "이미 존재하는 멤버입니다.", 10002),
 
   // jwt 영역
-  INVALID_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 토큰입니다.", 10100);
+  INVALID_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 토큰입니다.", 10100),
+
+  // follow 영역
+  INVALID_FOLLOW(HttpStatus.BAD_REQUEST, "잘못된 팔로우 요청입니다.", 10201),
+  FOLLOW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 팔로우한 대상입니다", 10202);
 
   private final HttpStatus statusCode;
   private final String message;

--- a/src/main/java/com/leets/team2/xclone/exception/ErrorInfo.java
+++ b/src/main/java/com/leets/team2/xclone/exception/ErrorInfo.java
@@ -19,7 +19,7 @@ public enum ErrorInfo {
   INVALID_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 토큰입니다.", 10100),
 
   // follow 영역
-  INVALID_FOLLOW(HttpStatus.BAD_REQUEST, "잘못된 팔로우 요청입니다.", 10201),
+  INVALID_FOLLOW(HttpStatus.BAD_REQUEST, "잘못된 팔로우 요청입니다. (자기 자신을 팔로우하거나 언팔로우할 수 없습니다.)", 10201),
   FOLLOW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 팔로우한 대상입니다", 10202),
   NO_SUCH_FOLLOW(HttpStatus.BAD_REQUEST, "팔로우하지 않은 대상입니다", 10203);
 

--- a/src/main/java/com/leets/team2/xclone/exception/ErrorInfo.java
+++ b/src/main/java/com/leets/team2/xclone/exception/ErrorInfo.java
@@ -20,7 +20,8 @@ public enum ErrorInfo {
 
   // follow 영역
   INVALID_FOLLOW(HttpStatus.BAD_REQUEST, "잘못된 팔로우 요청입니다.", 10201),
-  FOLLOW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 팔로우한 대상입니다", 10202);
+  FOLLOW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 팔로우한 대상입니다", 10202),
+  NO_SUCH_FOLLOW(HttpStatus.BAD_REQUEST, "팔로우하지 않은 대상입니다", 10203);
 
   private final HttpStatus statusCode;
   private final String message;

--- a/src/main/java/com/leets/team2/xclone/exception/FollowAlreadyExistsException.java
+++ b/src/main/java/com/leets/team2/xclone/exception/FollowAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.leets.team2.xclone.exception;
+
+public class FollowAlreadyExistsException extends ApplicationException{
+    public FollowAlreadyExistsException(){
+        super(ErrorInfo.FOLLOW_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/com/leets/team2/xclone/exception/InvalidFollowException.java
+++ b/src/main/java/com/leets/team2/xclone/exception/InvalidFollowException.java
@@ -1,0 +1,5 @@
+package com.leets.team2.xclone.exception;
+
+public class InvalidFollowException extends ApplicationException{
+    public InvalidFollowException(){super(ErrorInfo.INVALID_FOLLOW);}
+}

--- a/src/main/java/com/leets/team2/xclone/exception/NoSuchFollowException.java
+++ b/src/main/java/com/leets/team2/xclone/exception/NoSuchFollowException.java
@@ -1,0 +1,5 @@
+package com.leets.team2.xclone.exception;
+
+public class NoSuchFollowException extends ApplicationException{
+    public NoSuchFollowException(){super(ErrorInfo.NO_SUCH_FOLLOW);}
+}


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 팔로우 도메인 기능 구현
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
성공적으로 팔로우
![image](https://github.com/user-attachments/assets/62635870-81b9-4099-b39c-e67934d13c71)
같은 대상을 다시 팔로우(exception 처리)
![image](https://github.com/user-attachments/assets/cf7a26a5-0b05-4a5f-9a74-eb72e7bce52d)
팔로우가 되어있지 않은데 unfollow한 경우(exception 처리)
![image](https://github.com/user-attachments/assets/8d0c1747-5b0e-4470-b67a-ff5093bdf36f)
성공적으로 팔로우한 경우
![image](https://github.com/user-attachments/assets/2008117f-6511-4776-95d4-facd0a0dc9e7)



<br>

## 4. 완료 사항
- [x] 팔로우 기능
- [x] 팔로워 조회 기능
- [x] 팔로잉 조회 기능
- [x] 팔로우 취소 기능

<br>

## 5. 추가 사항
- 나중에 myTag가 아닌 현재 로그인한 유저의 정보를 이용해 follow와 unfollow하는게 좋아보입니다