### PR TITLE
Feat#49 멤버 조회 및 프로필 사진 수정 api 추가

### DIFF
--- a/src/main/java/com/leets/team2/xclone/domain/member/controller/MemberController.java
+++ b/src/main/java/com/leets/team2/xclone/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.leets.team2.xclone.domain.member.controller;
 
 import com.leets.team2.xclone.common.ApiData;
+import com.leets.team2.xclone.domain.member.dto.MemberDTO;
 import com.leets.team2.xclone.domain.member.dto.requests.CheckTagDuplicationGetRequest;
 import com.leets.team2.xclone.domain.member.dto.responses.CheckTagDuplicationGetResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 
 public interface MemberController {
 
@@ -15,4 +17,8 @@ public interface MemberController {
   @ApiResponse(responseCode = "200", description = "태그 중복확인 성공", content = @Content(schema = @Schema(implementation = CheckTagDuplicationGetResponse.class)))
   ResponseEntity<ApiData<CheckTagDuplicationGetResponse>> getCheckTagDuplication(
       CheckTagDuplicationGetRequest request);
+
+  @Operation(summary = "Member 찾기 API", description = "해당하는 멤버를 찾습니다.")
+  ResponseEntity<ApiData<MemberDTO.Response>> getMemberInfo(@RequestParam String tag);
+
 }

--- a/src/main/java/com/leets/team2/xclone/domain/member/controller/MemberController.java
+++ b/src/main/java/com/leets/team2/xclone/domain/member/controller/MemberController.java
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberController {
 
@@ -20,5 +22,8 @@ public interface MemberController {
 
   @Operation(summary = "Member 찾기 API", description = "해당하는 멤버를 찾습니다.")
   ResponseEntity<ApiData<MemberDTO.Response>> getMemberInfo(@RequestParam String tag);
+
+  @Operation(summary = "프로필 사진 수정 API", description = "자신의 프로필 사진을 수정합니다.")
+  ResponseEntity<ApiData<MemberDTO.Response>> updateProfilePicture(@RequestPart(value="image",required = false) MultipartFile image);
 
 }

--- a/src/main/java/com/leets/team2/xclone/domain/member/controller/MemberControllerImpl.java
+++ b/src/main/java/com/leets/team2/xclone/domain/member/controller/MemberControllerImpl.java
@@ -1,20 +1,20 @@
 package com.leets.team2.xclone.domain.member.controller;
 
 import com.leets.team2.xclone.common.ApiData;
+import com.leets.team2.xclone.common.auth.MemberContext;
+import com.leets.team2.xclone.common.auth.annotations.UseGuards;
+import com.leets.team2.xclone.common.auth.guards.MemberGuard;
 import com.leets.team2.xclone.domain.member.dto.MemberDTO;
 import com.leets.team2.xclone.domain.member.dto.requests.CheckTagDuplicationGetRequest;
 import com.leets.team2.xclone.domain.member.dto.responses.CheckTagDuplicationGetResponse;
 import com.leets.team2.xclone.domain.member.entities.Member;
 import com.leets.team2.xclone.domain.member.service.MemberService;
-import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Controller
 @RequestMapping("/api/members")
@@ -43,6 +43,14 @@ public class MemberControllerImpl implements MemberController{
             .introduction(targetMember.getIntroduction())
             .build();
 
+    return ApiData.ok(response);
+  }
+
+  @UseGuards({MemberGuard.class})
+  @PatchMapping("/profile/picture")
+  public ResponseEntity<ApiData<MemberDTO.Response>> updateProfilePicture(@RequestPart(value="image",required = false) MultipartFile image){
+    Member currentMember = MemberContext.getMember();
+    MemberDTO.Response response = memberService.updateProfilePicture(currentMember, image);
     return ApiData.ok(response);
   }
 

--- a/src/main/java/com/leets/team2/xclone/domain/member/controller/MemberControllerImpl.java
+++ b/src/main/java/com/leets/team2/xclone/domain/member/controller/MemberControllerImpl.java
@@ -1,9 +1,12 @@
 package com.leets.team2.xclone.domain.member.controller;
 
 import com.leets.team2.xclone.common.ApiData;
+import com.leets.team2.xclone.domain.member.dto.MemberDTO;
 import com.leets.team2.xclone.domain.member.dto.requests.CheckTagDuplicationGetRequest;
 import com.leets.team2.xclone.domain.member.dto.responses.CheckTagDuplicationGetResponse;
+import com.leets.team2.xclone.domain.member.entities.Member;
 import com.leets.team2.xclone.domain.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +14,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequestMapping("/api/members")
@@ -27,4 +31,19 @@ public class MemberControllerImpl implements MemberController{
         CheckTagDuplicationGetResponse.of(this.memberService.checkMemberExistsBy(request.tag()))
     );
   }
+
+  @Override
+  @GetMapping("")
+  public ResponseEntity<ApiData<MemberDTO.Response>> getMemberInfo(@RequestParam String tag) {
+    Member targetMember = memberService.findMemberByTag(tag);
+    MemberDTO.Response response = MemberDTO.Response.builder()
+            .birthDate(targetMember.getBirthDate())
+            .tag(targetMember.getTag())
+            .nickname(targetMember.getNickname())
+            .introduction(targetMember.getIntroduction())
+            .build();
+
+    return ApiData.ok(response);
+  }
+
 }

--- a/src/main/java/com/leets/team2/xclone/domain/member/dto/MemberDTO.java
+++ b/src/main/java/com/leets/team2/xclone/domain/member/dto/MemberDTO.java
@@ -10,6 +10,7 @@ public class MemberDTO {
             LocalDateTime birthDate,
             String tag,
             String nickname,
-            String introduction
+            String introduction,
+            String profilePicture
     ){}
 }

--- a/src/main/java/com/leets/team2/xclone/domain/member/dto/MemberDTO.java
+++ b/src/main/java/com/leets/team2/xclone/domain/member/dto/MemberDTO.java
@@ -1,0 +1,15 @@
+package com.leets.team2.xclone.domain.member.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public class MemberDTO {
+    @Builder
+    public record Response(
+            LocalDateTime birthDate,
+            String tag,
+            String nickname,
+            String introduction
+    ){}
+}

--- a/src/main/java/com/leets/team2/xclone/domain/member/entities/Member.java
+++ b/src/main/java/com/leets/team2/xclone/domain/member/entities/Member.java
@@ -1,10 +1,15 @@
 package com.leets.team2.xclone.domain.member.entities;
 
 import com.leets.team2.xclone.common.entity.AbstractEntity;
+import com.leets.team2.xclone.image.converter.ImageListConverter;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,4 +38,16 @@ public class Member extends AbstractEntity {
 
   @Column(name = "kakao_id", nullable = false, unique = true)
   private Long kakaoId;
+
+  @Column(name="image_url")
+  @Convert(converter = ImageListConverter.class)
+  private List<String> imageUrl = new ArrayList<>();
+
+  public void setImage(String profileImageUrl) {
+    if (this.imageUrl == null) {
+      this.imageUrl = new ArrayList<>();  // Initialize if it's null
+    }
+    this.imageUrl.clear();
+    this.imageUrl.add(profileImageUrl);
+  }
 }

--- a/src/main/java/com/leets/team2/xclone/domain/member/service/MemberService.java
+++ b/src/main/java/com/leets/team2/xclone/domain/member/service/MemberService.java
@@ -1,15 +1,17 @@
 package com.leets.team2.xclone.domain.member.service;
 
+import com.leets.team2.xclone.domain.member.dto.MemberDTO;
 import com.leets.team2.xclone.domain.member.entities.Member;
 import com.leets.team2.xclone.domain.member.repository.MemberRepository;
 import com.leets.team2.xclone.exception.NoSuchMemberException;
+import java.util.List;
 import java.util.Optional;
+import com.leets.team2.xclone.image.service.ImageSaveService;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.stereotype.Service;
-
-import java.util.NoSuchElementException;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +19,7 @@ public class MemberService {
 
   private static final Log log = LogFactory.getLog(MemberService.class);
   private final MemberRepository memberRepository;
+  private final ImageSaveService imageSaveService;
 
   public boolean checkMemberExistsBy(String nickname, Long kakaoId) {
     return this.memberRepository.existsByNicknameAndKakaoId(nickname, kakaoId);
@@ -46,5 +49,21 @@ public class MemberService {
   public Member findMemberByTag(String tag){
     return this.memberRepository.findByTag(tag).orElseThrow(
             NoSuchMemberException::new);
+  }
+
+  public MemberDTO.Response updateProfilePicture(Member currentMember, MultipartFile image) {
+
+    if(!image.isEmpty()){
+      List<String> imageUrl = imageSaveService.uploadImages(List.of(image));
+      currentMember.setImage(imageUrl.get(0));
+    }
+    memberRepository.save(currentMember);
+    return MemberDTO.Response.builder()
+            .birthDate(currentMember.getBirthDate())
+            .tag(currentMember.getTag())
+            .nickname(currentMember.getNickname())
+            .introduction(currentMember.getIntroduction())
+            .profilePicture(currentMember.getImageUrl().get(0))
+            .build();
   }
 }

--- a/src/main/java/com/leets/team2/xclone/image/converter/ImageListConverter.java
+++ b/src/main/java/com/leets/team2/xclone/image/converter/ImageListConverter.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.AttributeConverter;
-
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ImageListConverter implements AttributeConverter<List<String>, String> {
@@ -16,6 +16,9 @@ public class ImageListConverter implements AttributeConverter<List<String>, Stri
 
     @Override
     public String convertToDatabaseColumn(List<String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return "";
+        }
         try {
             return mapper.writeValueAsString(attribute);
         } catch (JsonProcessingException e) {
@@ -25,6 +28,9 @@ public class ImageListConverter implements AttributeConverter<List<String>, Stri
 
     @Override
     public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isEmpty()) {
+            return new ArrayList<>(); // Return an empty list if dbData is null or empty
+        }
         try {
             return mapper.readValue(dbData, new TypeReference<>() {});
         } catch (IOException e) {


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- tag를 이용해 멤버의 정보를 가져오는 api 필요
- 멤버의 프로필 사진을 수정하는 api 필요
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- 기존에 사용하던 코드를 재사용하여 프로필 사진이 List로 있지만 0번 인덱스만 사용합니다
<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/user-attachments/assets/fe77b300-79e3-4e77-8f67-9fbe133e911e)

<br>

## 4. 완료 사항
- [x]tag를 이용해 멤버의 정보를 가져오는 api 구현
- [x] 멤버의 프로필 사진을 수정하는 api 구현
<br>

## 5. 추가 사항
- 2번에 언급한 거처럼 프로필 사진을 List 형태로 사용합니다!