### PR TITLE
fix: 게시글 생성/수정 시 사진 미첨부 시 발생하던 오류 수정

### DIFF
--- a/src/main/java/com/leets/team2/xclone/domain/post/service/PostService.java
+++ b/src/main/java/com/leets/team2/xclone/domain/post/service/PostService.java
@@ -32,10 +32,14 @@ public class PostService {
     private final ImageSaveService imageSaveService;
     private final FollowService followService;
 
-    public Post createPost(PostRequestDTO postRequestDTO, Member author, List<MultipartFile> images) throws IOException {
-        List<String> imageUrls;
-        imageUrls = imageSaveService.uploadImages(images);
-
+    public Post createPost(PostRequestDTO postRequestDTO, Member author, List<MultipartFile> images) {
+        List<String> imageUrls = new ArrayList<>();
+        if (images != null && images.stream().anyMatch(file -> !file.isEmpty())) {
+            List<MultipartFile> nonEmptyImages = images.stream()
+                    .filter(file -> !file.isEmpty())
+                    .toList();
+            imageUrls = imageSaveService.uploadImages(nonEmptyImages);
+        }
 
         Post parentPost=null;
         if(postRequestDTO.getParentPostId()!=null){
@@ -70,9 +74,15 @@ public class PostService {
         }
         post.setContent(postEditRequestDTO.getContent());
 
-        if(!images.isEmpty()){//새로운 이미지가 있을 경우 원래 있던 이미지 삭제하고 업데이트한다.
-            List<String> imageUrls;
-            imageUrls = imageSaveService.uploadImages(images);
+        List<String> imageUrls = new ArrayList<>();
+        if (images != null && images.stream().anyMatch(file -> !file.isEmpty())) {
+            List<MultipartFile> nonEmptyImages = images.stream()
+                    .filter(file -> !file.isEmpty())
+                    .toList();
+            imageUrls = imageSaveService.uploadImages(nonEmptyImages);
+            post.setImageUrls(imageUrls);
+        }
+        else{
             post.setImageUrls(imageUrls);
         }
         return postRepository.save(post);


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- Post 생성할 때 이미지를 받아오지 않을 때 없는 이미지를 변환하기 위해 ImageListConverter에서 에러가 났습니다
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- 없습니다
<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/user-attachments/assets/bc7c32c2-8f4b-4620-a5d3-215469892153)

<br>

## 4. 완료 사항
- 1-1 수정했습니다
<br>

## 5. 추가 사항
- 없습니다